### PR TITLE
Remove check that relies on deprecated GU_MI cookie

### DIFF
--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/LoginTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/LoginTests.scala
@@ -22,7 +22,6 @@ class LoginTests extends IdentitySeleniumTestSuite {
       SignInSteps().signInUsingFaceBook()
       SignInSteps().checkUserIsLoggedIn(Config().getUserValue("faceBookLoginName"))
       SignInSteps().checkUserIsLoggedInSecurely()
-      SignInSteps().checkLoggedInThroughSocialMedia()
     }
 
     scenarioWeb("should be able to login using existing Google account") { implicit driver: WebDriver =>
@@ -30,7 +29,6 @@ class LoginTests extends IdentitySeleniumTestSuite {
       SignInSteps().signInUsingGoogle()
       SignInSteps().checkUserIsLoggedIn(Config().getUserValue("googleLoginName"))
       SignInSteps().checkUserIsLoggedInSecurely()
-      SignInSteps().checkLoggedInThroughSocialMedia()
     }
   }
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -15,7 +15,6 @@ import org.scalatest.Matchers
 case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
   private val LoginCookie: String = "GU_U"
   private val SecureLoginCookie: String = "SC_GU_U"
-  private val SocialMediaCookieMI: String = "GU_MI"
 
   def clickSignInLink(): SignInPage = {
     logger.step("Clicking sign in link")
@@ -81,12 +80,6 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
     googleSignInPage.enterEmail(Config().getUserValue("googleEmail"))
     googleSignInPage.enterPwd(Config().getUserValue("googlePwd"))
     googleSignInPage.loginInButton.click()
-  }
-
-  def checkLoggedInThroughSocialMedia() = {
-    logger.step(s"Checking that user is logged in through Social Media")
-    val loginCookieMI = getCookie(SocialMediaCookieMI)
-    loginCookieMI.getValue should not be empty
   }
 
   def signOut(pageWithSignInModule: ContainerWithSigninModulePage) = {


### PR DESCRIPTION
On the old R2 site, there was a cookie called `GU_MI` that related to social media logins.

It is deprecated in NextGen, but is still referenced and used in the functional tests.