### PR TITLE
Remove the OAuth switch query parameter in login tests

### DIFF
--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
@@ -39,11 +39,6 @@ class SignInPage(implicit driver: WebDriver) extends ParentPage {
     new GoogleSignInPage()
   }
 
-  def switchToNewSignIn(): SignInPage = {
-    driver.get(driver.getCurrentUrl + "?switchesOn=id-social-oauth")
-    this
-  }
-
   def clickRegisterNewUserLink(): RegisterPage = {
     registerLink.click()
     new RegisterPage()

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -67,7 +67,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   def signInUsingNewFaceBook() = {
     logger.step(s"Signing in using FaceBook")
     val signInPage = SignInSteps().clickSignInLink()
-    val faceBookSignInPage = signInPage.switchToNewSignIn().clickFaceBookSignInButton()
+    val faceBookSignInPage = signInPage.clickFaceBookSignInButton()
     faceBookSignInPage.enterEmail(Config().getUserValue("faceBookEmail"))
     faceBookSignInPage.enterPwd(Config().getUserValue("faceBookPwd"))
     faceBookSignInPage.loginInButton.click()
@@ -76,7 +76,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   def signInUsingGoogle() = {
     logger.step(s"Signing in using Google")
     val signInPage = SignInSteps().clickSignInLink()
-    val googleSignInPage = signInPage.switchToNewSignIn().clickGoogleSignInButton()
+    val googleSignInPage = signInPage.clickGoogleSignInButton()
     googleSignInPage.enterEmail(Config().getUserValue("googleEmail"))
     googleSignInPage.enterPwd(Config().getUserValue("googlePwd"))
     googleSignInPage.loginInButton.click()


### PR DESCRIPTION
No longer needed since OAuth is now default in CODE.

As a side effect, this makes the Google sign-in test pass, since the `returnUrl` is now preserved between hitting the front page and going to the Google login. Previously, the test would reload the sign-in screen to add the OAuth switch and that caused the `returnUrl` to be unset (as well as losing the HTTP referrer header).