### PR TITLE
Fix Facebook auto sign in test by properly logging out and modifying the log out cookie

### DIFF
--- a/common-test-lib/src/main/scala/com/gu/integration/test/util/CookieUtil.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/util/CookieUtil.scala
@@ -11,6 +11,11 @@ object CookieUtil {
     driver.manage().deleteCookieNamed(cookieName)
   }
 
+  def createCookie(cookieName: String, content: String)(implicit driver: WebDriver) = {
+    val cookie = new Cookie(cookieName, content)
+    driver.manage().addCookie(cookie)
+  }
+
   /**
    * Use this to get a secure cookie. Make sure you either are on an HTTPS address or provide one as a param
    */

--- a/common-test-lib/src/main/scala/com/gu/integration/test/util/CookieUtil.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/util/CookieUtil.scala
@@ -7,10 +7,12 @@ object CookieUtil {
     driver.manage().getCookieNamed(cookieName)
   }
 
+  @deprecated
   def removeCookie(cookieName: String)(implicit driver: WebDriver) = {
     driver.manage().deleteCookieNamed(cookieName)
   }
 
+  @deprecated
   def createCookie(cookieName: String, content: String)(implicit driver: WebDriver) = {
     val cookie = new Cookie(cookieName, content)
     driver.manage().addCookie(cookie)

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FrontPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FrontPage.scala
@@ -1,10 +1,9 @@
 package com.gu.identity.integration.test.pages
 
-import com.gu.integration.test.pages.common.ParentPage
 import org.openqa.selenium.support.ui.{ExpectedConditions, WebDriverWait}
 import org.openqa.selenium.{WebElement, By, WebDriver}
 
-class FrontPage(implicit driver: WebDriver) extends ParentPage {
+class FrontPage(implicit driver: WebDriver) extends ContainerWithSigninModulePage {
 
   private def getSiteMessage(): Option[WebElement] =  {
     try {

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -49,6 +49,7 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
       SignInSteps().signOut(frontPage)
       val newLogOutTime = System.currentTimeMillis / 1000 - 24 * 3600
       SignInSteps().setSignOutCookieWithTime(newLogOutTime)
+      SocialNetworkSteps().clearLocalStorageFacebookValue()
       BaseSteps().goToStartPage()
       SocialNetworkSteps().checkUserGotAutoSignInBanner(frontPage)
       SignInSteps().checkUserIsLoggedIn(facebookUser.fullName)

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -46,7 +46,9 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
       val registerPage = SignInSteps().clickSignInLink().clickRegisterNewUserLink()
       val authDialog = registerPage.switchToNewSignIn().clickRegisterWithFacebookButton()
       authDialog.clickConfirmButton()
-      SignInSteps().clearLoginCookies()
+      SignInSteps().signOut(frontPage)
+      val newLogOutTime = System.currentTimeMillis / 1000 - 24 * 3600
+      SignInSteps().setSignOutCookieWithTime(newLogOutTime)
       BaseSteps().goToStartPage()
       SocialNetworkSteps().checkUserGotAutoSignInBanner(frontPage)
       SignInSteps().checkUserIsLoggedIn(facebookUser.fullName)

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -15,6 +15,7 @@ import org.scalatest.Matchers
 case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
   private val LoginCookie: String = "GU_U"
   private val SecureLoginCookie: String = "SC_GU_U"
+  private val SignOutCookie: String = "GU_SO"
 
   def clickSignInLink(): SignInPage = {
     logger.step("Clicking sign in link")
@@ -99,6 +100,15 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   def clearLoginCookies() = {
     removeCookie(LoginCookie)
     removeCookie(SecureLoginCookie)
+  }
+
+  def clearSignOutCookie() = {
+    removeCookie(SignOutCookie)
+  }
+
+  def setSignOutCookieWithTime(time: Long) = {
+    clearSignOutCookie()
+    createCookie(SignOutCookie, time.toString)
   }
 
   def checkThatLoginCookieExists() = {

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -1,6 +1,6 @@
 package com.gu.identity.integration.test.steps
 
-import com.gu.automation.support.{Config, TestLogging}
+import com.gu.automation.support.{CookieManager, Config, TestLogging}
 import com.gu.identity.integration.test.pages.{ContainerWithSigninModulePage, SignInPage}
 import com.gu.identity.integration.test.util.User
 import com.gu.integration.test.steps.BaseSteps
@@ -98,17 +98,17 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   }
 
   def clearLoginCookies() = {
-    removeCookie(LoginCookie)
-    removeCookie(SecureLoginCookie)
+    CookieManager.removeCookie(LoginCookie)
+    CookieManager.removeCookie(SecureLoginCookie)
   }
 
   def clearSignOutCookie() = {
-    removeCookie(SignOutCookie)
+    CookieManager.removeCookie(SignOutCookie)
   }
 
   def setSignOutCookieWithTime(time: Long) = {
     clearSignOutCookie()
-    createCookie(SignOutCookie, time.toString)
+    CookieManager.addCookie(SignOutCookie, time.toString)
   }
 
   def checkThatLoginCookieExists() = {

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SocialNetworkSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SocialNetworkSteps.scala
@@ -1,6 +1,6 @@
 package com.gu.integration.test.steps
 
-import com.gu.automation.support.{Config, TestLogging}
+import com.gu.automation.support.{LocalStorageManager, Config, TestLogging}
 import com.gu.identity.integration.test.pages.{FrontPage, RegisterPage, FacebookParentPage}
 import com.gu.identity.integration.test.util.facebook.{FacebookTestUserService, AccessToken, FacebookTestUser}
 import com.gu.integration.test.util.PageLoader._
@@ -9,6 +9,8 @@ import org.openqa.selenium.{By, WebDriver}
 import org.scalatest.Matchers
 
 case class SocialNetworkSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
+
+  private val facebookLocalStorageKey = "gu.id.nextFbCheck"
 
   def accessToken(): AccessToken = AccessToken(Config().getUserValue("facebookApplicationId"), Config().getUserValue("facebookApplicationSecret"))
 
@@ -47,6 +49,10 @@ case class SocialNetworkSteps(implicit driver: WebDriver) extends TestLogging wi
       case Some(text: String) => text should include ("signed into the Guardian using Facebook")
       case _ => fail("Did not get auto sign in banner")
     }
+  }
+
+  def clearLocalStorageFacebookValue() = {
+    LocalStorageManager.remove(facebookLocalStorageKey)
   }
 
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object Build extends Build {
       "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/",
       "Maven Central" at "http://repo1.maven.org/maven2/"),
     libraryDependencies ++= Seq(
-      "com.gu" %% "scala-automation" % "1.34",
+      "com.gu" %% "scala-automation" % "1.48",
       "com.sun.mail" % "javax.mail" % "1.5.2",
       "com.sun.mail" % "imap" % "1.5.2",
       "com.stackmob" %% "newman" % "1.3.5",


### PR DESCRIPTION
If the log out is performed via the menu and the sign out cookie (`GU_SO`) is updated to a time 24 hours ago, the actions fall within the scope of the auto sign-in feature.