### PR TITLE
Fix Facebook login button identifier

### DIFF
--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookParentPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookParentPage.scala
@@ -8,7 +8,7 @@ class FacebookParentPage(implicit driver: WebDriver) extends ParentPage {
   private def emailInputField: WebElement = driver.findElement(By.id("email"))
   private def passwordInputField: WebElement = driver.findElement(By.id("pass"))
 
-  private def loginInButton: WebElement = driver.findElement(By.xpath("//input[@value='Log in']"))
+  private def loginInButton: WebElement = driver.findElement(By.cssSelector("#loginbutton"))
 
   def clickLoginButton() = {
     loginInButton.click()

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookParentPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookParentPage.scala
@@ -8,7 +8,7 @@ class FacebookParentPage(implicit driver: WebDriver) extends ParentPage {
   private def emailInputField: WebElement = driver.findElement(By.id("email"))
   private def passwordInputField: WebElement = driver.findElement(By.id("pass"))
 
-  private def loginInButton: WebElement = driver.findElement(By.cssSelector("#loginbutton"))
+  private def loginInButton: WebElement = driver.findElement(By.id("loginbutton"))
 
   def clickLoginButton() = {
     loginInButton.click()


### PR DESCRIPTION
Looks like Facebook is doing A/B testing on capitalising the 'i' in the submit button during log in. This uses a unique CSS identifier instead.