### PR TITLE
Enable local runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ frontend/assets/stylesheets/icons/icons.scss
 frontend/public/
 
 npm-debug.log
+dev.conf

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ frontend/public/
 
 npm-debug.log
 dev.conf
+code.conf

--- a/common-test-lib/src/main/scala/com/gu/integration/test/util/ConfigUtil.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/util/ConfigUtil.scala
@@ -1,0 +1,15 @@
+package com.gu.integration.test.util
+
+import com.gu.integration.test.util.FileUtil._
+
+object ConfigUtil {
+
+  def getConfigFilename(): String = {
+    val configFilename = System.getProperty("config.resource") match {
+      case filename: String => filename
+      case null => "local.conf"
+    }
+    s"${currentPath()}/identity-tests/${configFilename}"
+  }
+
+}

--- a/identity-tests/src/main/resources/project.conf
+++ b/identity-tests/src/main/resources/project.conf
@@ -1,6 +1,3 @@
-"testBaseUrl": "http://m.code.dev-theguardian.com/uk"
-"idApiRoot" : "https://idapi.code.dev-theguardian.com"
-
 "browsers": [{"name": "firefox", "version": "30"}, {"name": "chrome", "version": "35"}]
 
 "environment": "sauceLabs" //value of sauceLabs or browserStack will use the corresponding object below for picking up values
@@ -31,7 +28,4 @@
   "googleEmail": ""
   "googlePwd": ""
   "googleLoginName": "" //observe that guardian uses the facebook name if you use the same email for Google+ and Facebook signin
-  "secureEditProfileLink": "https://profile.code.dev-theguardian.com/public/edit" //this is needed because, on Chrome, secure cookies can only be seen on https pages,
-  "changePassword" : "https://profile.code.dev-theguardian.com/password/change"
-  "signOut" : "https://profile.code.dev-theguardian.com/signout"
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/IdentitySeleniumTestSuite.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/IdentitySeleniumTestSuite.scala
@@ -1,8 +1,8 @@
 package com.gu.identity.integration.test
 
 import com.gu.integration.test.SeleniumTestSuite
-import com.gu.integration.test.util.FileUtil._
 import com.gu.integration.test.util.PropertyUtil._
+import com.gu.integration.test.util.ConfigUtil._
 
 trait IdentitySeleniumTestSuite extends SeleniumTestSuite {
   //only used because of the need to have a static init block, which the companion object below acts as
@@ -12,6 +12,6 @@ trait IdentitySeleniumTestSuite extends SeleniumTestSuite {
 object IdentitySeleniumTestSuite {
   //this is needed because of the sbt multimodule nature of this test project
   //without it, it will try to load the local.conf from the root folder
-  setLocalConfProperty(s"${currentPath()}/identity-tests/local.conf")
+  setLocalConfProperty(getConfigFilename())
 }
 

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+CONF_FILE="local.conf"
+if [[ $1 = "code" ]]; then
+    CONF_FILE="dev.conf"
+fi
+
+echo "${CONF_FILE}"
+sbt -Dconfig.resource=${CONF_FILE} "project identity-tests" "test"

--- a/tests.sh
+++ b/tests.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
-CONF_FILE="local.conf"
-if [[ $1 = "code" ]]; then
-    CONF_FILE="dev.conf"
+
+which aws 1>/dev/null || exit 1
+
+BUCKET="identity-functional-tests"
+
+LOCAL_CONF_FILE="dev.conf"
+REMOTE_CONF_FILE="s3://${BUCKET}/DEV/dev.conf"
+if [ "$1" = "code" ]; then
+    LOCAL_CONF_FILE="code.conf"
+    REMOTE_CONF_FILE="s3://${BUCKET}/CODE/code.conf"
 fi
 
-echo "${CONF_FILE}"
-sbt -Dconfig.resource=${CONF_FILE} "project identity-tests" "test"
+if [ ! -f "./identity-tests/${LOCAL_CONF_FILE}" ]; then
+    aws s3 cp "${REMOTE_CONF_FILE}" "./identity-tests/${LOCAL_CONF_FILE}"
+fi
+
+echo "Running tests using config file: ${LOCAL_CONF_FILE}"
+sbt -Dconfig.resource=${LOCAL_CONF_FILE} "project identity-tests" "test"

--- a/tests.sh
+++ b/tests.sh
@@ -9,6 +9,16 @@ REMOTE_CONF_FILE="s3://${BUCKET}/DEV/dev.conf"
 if [ "$1" = "code" ]; then
     LOCAL_CONF_FILE="code.conf"
     REMOTE_CONF_FILE="s3://${BUCKET}/CODE/code.conf"
+    shift
+fi
+
+SBT_ARGUMENTS="test"
+if [ $# -gt 0 ]; then
+    SBT_ARGUMENTS=""
+    for t in $@; do
+        TEST_ARGUMENT="test-only com.gu.identity.integration.test.features.${t}"
+        SBT_ARGUMENTS=${SBT_ARGUMENTS}" "${TEST_ARGUMENT}
+    done
 fi
 
 if [ ! -f "./identity-tests/${LOCAL_CONF_FILE}" ]; then
@@ -16,4 +26,4 @@ if [ ! -f "./identity-tests/${LOCAL_CONF_FILE}" ]; then
 fi
 
 echo "Running tests using config file: ${LOCAL_CONF_FILE}"
-sbt -Dconfig.resource=${LOCAL_CONF_FILE} "project identity-tests" "test"
+sbt -Dconfig.resource=${LOCAL_CONF_FILE} "project identity-tests" "${SBT_ARGUMENTS}"


### PR DESCRIPTION
Make it possible to run the functional tests against local instances `./tests.sh` or against CODE `./tests.sh code`

The `tests.sh` wrapper also downloads any non-existing configuration from S3.