### PR TITLE
re-enable google social sign in tests

### DIFF
--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/LoginTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/LoginTests.scala
@@ -24,11 +24,11 @@ class LoginTests extends IdentitySeleniumTestSuite {
       SignInSteps().checkUserIsLoggedInSecurely()
     }
 
-//    scenarioWeb("should be able to login using existing Google account") { implicit driver: WebDriver =>
-//      BaseSteps().goToStartPage()
-//      SignInSteps().signInUsingGoogle()
-//      SignInSteps().checkUserIsLoggedIn(Config().getUserValue("googleLoginName"))
-//      SignInSteps().checkUserIsLoggedInSecurely()
-//    }
+    scenarioWeb("should be able to login using existing Google account") { implicit driver: WebDriver =>
+      BaseSteps().goToStartPage()
+      SignInSteps().signInUsingGoogle()
+      SignInSteps().checkUserIsLoggedIn(Config().getUserValue("googleLoginName"))
+      SignInSteps().checkUserIsLoggedInSecurely()
+    }
   }
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -82,7 +82,6 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
       SocialNetworkSteps().deleteFacebookTestUser(facebookUser)
     }
 
-    /*
     scenarioWeb("should be asked to re-authenticate when editing profile after logging in with Google") { implicit driver: WebDriver =>
       BaseSteps().goToStartPage()
       SignInSteps().signInUsingGoogle()
@@ -92,6 +91,6 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
       val editProfilePage = googleConfirmPasswordDialog.clickChooseAccountButton()
       SocialNetworkSteps().checkUserIsOnEditProfilePage(editProfilePage)
     }
-    */
+
   }
 }


### PR DESCRIPTION
IT have disabled 2 factor auth for the google user, so these tests can be re-enabled. @nlindblad 