### PR TITLE
Disable Facebook tests

### DIFF
--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -8,7 +8,7 @@ import org.openqa.selenium.WebDriver
 
 
 class SocialNetworkTests extends IdentitySeleniumTestSuite {
-
+  /*
   feature("Registration and sign-in using Facebook") {
     scenarioWeb("should be able to register using Facebook") { implicit driver: WebDriver =>
       val facebookUser = SocialNetworkSteps().createNewFacebookTestUser()
@@ -117,5 +117,5 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
         .clickEditAccountDetailsTab().getEmailAddress()
       signInEmail should be(newEmail)
     }
-  }
+  }*/
 }


### PR DESCRIPTION
Facebook changed the test user API, so all tests that rely on creating a new Facebook user now fails.

It looks like the functionality is still there (https://developers.facebook.com/docs/graph-api/reference/v2.3/app/accounts/test-users), but the API has changed slightly.

This disables the tests for now until we update our side to adhere to the new API.