### PR TITLE
removes javascript scrolling which was causing the tests to fail

### DIFF
--- a/common-test-lib/src/main/scala/com/gu/integration/test/steps/BaseSteps.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/steps/BaseSteps.scala
@@ -2,6 +2,7 @@ package com.gu.integration.test.steps
 
 import com.gu.automation.support.TestLogging
 import com.gu.integration.test.pages.common.{ParentPage, TermsOfServicePage}
+import com.gu.integration.test.util.ElementLoader
 import com.gu.integration.test.util.PageLoader._
 import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
@@ -14,8 +15,11 @@ case class BaseSteps(implicit driver: WebDriver) extends TestLogging with Matche
   }
 
   def goToTermsOfServicePage(useBetaRedirect: Boolean = false): TermsOfServicePage = {
-    logger.step(s"I am on base page at url: $frontsBaseUrl")
-    lazy val tosPage = new TermsOfServicePage()
-    goTo(tosPage, fromRelativeUrl("/../help/terms-of-service"))
+    goToStartPage()
+    //    lazy val tosPage = new TermsOfServicePage()
+    //    goTo(tosPage, fromRelativeUrl("/../help/terms-of-service"))
+    ElementLoader.findByDataLinkAttribute("terms").click()
+    logger.step(s"I am on the Terms of Service page at url: " + driver.getCurrentUrl)
+    new TermsOfServicePage()
   }
 }

--- a/common-test-lib/src/main/scala/com/gu/integration/test/util/ElementLoader.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/util/ElementLoader.scala
@@ -10,13 +10,14 @@ import scala.collection.JavaConverters.asScalaBufferConverter
 object ElementLoader extends TestLogging {
 
   val TestAttributeName = "data-test-id"
+  val DataLinkAttributeName = "data-link-name"
 
   def notDisplayed(elementsToCheck: List[WebElement]): List[WebElement] = {
-    elementsToCheck.filter(element => !element.isDisplayed())
+    elementsToCheck.filter(element => !element.isDisplayed)
   }
 
   def displayed(elementsToCheck: List[WebElement]): List[WebElement] = {
-    elementsToCheck.filter(element => element.isDisplayed())
+    elementsToCheck.filter(element => element.isDisplayed)
   }
 
   /**
@@ -25,6 +26,10 @@ object ElementLoader extends TestLogging {
    */
   def findByTestAttribute(testAttributeValue: String, contextElement: Option[SearchContext] = None)(implicit driver: WebDriver): WebElement = {
     contextElement.getOrElse(driver).findElement(byTestAttributeId(testAttributeValue))
+  }
+
+  def findByDataLinkAttribute(testAttributeValue: String, contextElement: Option[SearchContext] = None)(implicit driver: WebDriver): WebElement = {
+    contextElement.getOrElse(driver).findElement(byDataLinkAttributeName(testAttributeValue))
   }
 
   /**
@@ -37,6 +42,10 @@ object ElementLoader extends TestLogging {
 
   private def byTestAttributeId(testAttributeValue: String): org.openqa.selenium.By = {
     By.cssSelector(s"[$TestAttributeName=$testAttributeValue]")
+  }
+
+  private def byDataLinkAttributeName(name: String): org.openqa.selenium.By = {
+    By.cssSelector(s"[$DataLinkAttributeName=$name]")
   }
 
   /**
@@ -55,7 +64,7 @@ object ElementLoader extends TestLogging {
    */
   def displayedElements(elements: List[WebElement], timeoutInSeconds: Int = 3, maxElements: Int = Int.MaxValue)(implicit driver: WebDriver): List[WebElement] = {
     elements.view
-      .filter(element => waitUntil(visibilityOf(element), timeoutInSeconds) && element.isDisplayed())
+      .filter(element => waitUntil(visibilityOf(element), timeoutInSeconds) && element.isDisplayed)
       .take(maxElements)
       .toList
   }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
@@ -2,15 +2,21 @@ package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.util.ElementLoader._
 import com.gu.integration.test.util.WebElementEnhancer._
-import org.openqa.selenium.{By, JavascriptExecutor, WebDriver, WebElement}
+import org.openqa.selenium.{By, WebDriver, WebElement}
 
 class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
   private def emailInputField: WebElement = findByTestAttribute("reg-email")
+
   private def userNameInputField: WebElement = findByTestAttribute("reg-username")
+
   private def firstNameInputField: WebElement = findByTestAttribute("reg-first-name")
+
   private def lastNameInputField: WebElement = findByTestAttribute("reg-second-name")
+
   private def pwdInputField: WebElement = findByTestAttribute("reg-pwd")
+
   private def createButton: WebElement = findByTestAttribute("create-user-button")
+
   private def registerWithFacebookButton: WebElement = findByTestAttribute("facebook-sign-in")
 
   def enterEmail(email: String) = {
@@ -45,8 +51,8 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
   }
 
   def clickRegisterWithFacebookButton(): FaceBookAuthDialog = {
-    driver.asInstanceOf[JavascriptExecutor].executeScript("arguments[0].scrollIntoView(true);", registerWithFacebookButton);
-    Thread sleep 500
+//    driver.asInstanceOf[JavascriptExecutor].executeScript("arguments[0].scrollIntoView(true);", registerWithFacebookButton); //workaround for large ads
+//    Thread sleep 500
     registerWithFacebookButton.click()
     new FaceBookAuthDialog()
   }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInModule.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInModule.scala
@@ -3,7 +3,7 @@ package com.gu.identity.integration.test.pages
 import com.gu.integration.test.pages.common.ParentPage
 import com.gu.integration.test.util.ElementLoader._
 import org.openqa.selenium.interactions.Actions
-import org.openqa.selenium.{JavascriptExecutor, WebDriver, WebElement}
+import org.openqa.selenium.{WebDriver, WebElement}
 
 /**
  * Do not confuse this with the sign in page. This is only the module which sits at the top of most frontend pages
@@ -20,7 +20,7 @@ class SignInModule(implicit driver: WebDriver) extends ParentPage {
 
   def clickSignInLinkWhenLoggedIn(): ProfileNavMenu = {
     val y = signInLink.getLocation
-    driver.asInstanceOf[JavascriptExecutor].executeScript(s"window.scrollTo(0, $y)")
+ //   driver.asInstanceOf[JavascriptExecutor].executeScript(s"window.scrollTo(0, $y)") //workaround for large ads
     signInLink.click()
     new ProfileNavMenu
   }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsOfServiceTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsOfServiceTests.scala
@@ -13,12 +13,12 @@ class TermsOfServiceTests extends IdentitySeleniumTestSuite {
       val minimumTosContentSize = 100
       val tosContent: String = tosPage.getContent()
 
-      tosContent.size should be > minimumTosContentSize
+      tosContent.length should be > minimumTosContentSize
 
-      tosContent.contains("Terms and conditions") should be (true)
-      tosContent.contains("Guardian") should be (true)
-      tosContent.contains("theguardian.com") should be (true)
-      tosContent.contains("disclaimer") should be (true)
+      tosContent.contains("Terms and conditions") should be (right = true)
+      tosContent.contains("Guardian") should be (right = true)
+      tosContent.contains("theguardian.com") should be (right = true)
+      tosContent.contains("disclaimer") should be (right = true)
     }
   }
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
@@ -20,7 +20,7 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       val validationErrors = UserSteps().createUserWithUserName(get("loginName")).left.value
       validationErrors.size should be(2)
 
-      validationErrors.exists(_.errorText.contains("username")) should be (true)
+      validationErrors.exists(_.errorText.contains("username")) should be (right = true)
     }
 
     scenarioWeb("should be able to change email address", CoreTest) { implicit driver: WebDriver =>
@@ -37,7 +37,7 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       val invalidEmail = generateRandomAlphaNumericString(7)
       val validationErrors = UserSteps().changeEmailTo(invalidEmail, editAccountDetailsModule).left.value
       validationErrors.size should be(1)
-      validationErrors.head.errorText.contains("email") should be(true)
+      validationErrors.head.errorText.contains("email") should be(right = true)
     }
 
     scenarioWeb("should be able to set and change first and last name", OptionalTest) { implicit driver: WebDriver =>


### PR DESCRIPTION
Made 2 minor changes in SignInModule and RegisterPage by commenting out a forced scroll which was pushing the clickable elements out of view.  I am unsure what those were originally there for but it appears that the frontend has changed so these are no longer required.

I also updated the TOS tests to use a click action on the terms of service link rather than going directly to the TOS url.