### PR TITLE
Add test for registration return URL

### DIFF
--- a/common-test-lib/src/main/scala/com/gu/integration/test/steps/BaseSteps.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/steps/BaseSteps.scala
@@ -8,10 +8,11 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
 
 case class BaseSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
-  def goToStartPage(useBetaRedirect: Boolean = false): ParentPage = {
-    logger.step(s"I am on base page at url: $frontsBaseUrl")
+  def goToStartPage(useBetaRedirect: Boolean = false, subPath: Option[String] = None): ParentPage = {
+    val fullFrontBaseUrl = frontsBaseUrl + subPath.getOrElse("")
+    logger.step(s"I am on base page at url: $fullFrontBaseUrl")
     lazy val parentPage = new ParentPage()
-    goTo(parentPage, frontsBaseUrl, useBetaRedirect)
+    goTo(parentPage, fullFrontBaseUrl, useBetaRedirect)
   }
 
   def goToTermsOfServicePage(useBetaRedirect: Boolean = false): TermsOfServicePage = {

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EmailVerificationPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EmailVerificationPage.scala
@@ -1,0 +1,14 @@
+package com.gu.identity.integration.test.pages
+
+import com.gu.integration.test.pages.common.ParentPage
+import com.gu.integration.test.util.ElementLoader._
+import org.openqa.selenium.{By, WebDriver, WebElement}
+
+class EmailVerificationPage(implicit driver: WebDriver) extends ParentPage {
+  private def completeRegistrationButton: WebElement = findByDataLinkAttribute("Continue")
+
+  def getCompleteRegistrationButtonLink: String = {
+    completeRegistrationButton.getAttribute("href")
+  }
+
+}

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EmailVerificationPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EmailVerificationPage.scala
@@ -2,12 +2,14 @@ package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.pages.common.ParentPage
 import com.gu.integration.test.util.ElementLoader._
+import org.openqa.selenium.support.ui.{ExpectedConditions, WebDriverWait}
 import org.openqa.selenium.{By, WebDriver, WebElement}
 
 class EmailVerificationPage(implicit driver: WebDriver) extends ParentPage {
   private def completeRegistrationButton: WebElement = findByDataLinkAttribute("Continue")
 
   def getCompleteRegistrationButtonLink: String = {
+    new WebDriverWait(driver, 10).until(ExpectedConditions.presenceOfElementLocated(By.tagName("html")))
     completeRegistrationButton.getAttribute("href")
   }
 

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
@@ -1,12 +1,13 @@
 package com.gu.identity.integration.test.features
 
 import com.gu.identity.integration.test.IdentitySeleniumTestSuite
-import com.gu.identity.integration.test.pages.{ContainerWithSigninModulePage, EditAccountDetailsModule}
+import com.gu.identity.integration.test.pages.{EmailVerificationPage, ContainerWithSigninModulePage, EditAccountDetailsModule}
 import com.gu.identity.integration.test.steps.{SignInSteps, UserSteps}
 import com.gu.identity.integration.test.tags.{CoreTest, OptionalTest}
 import com.gu.identity.integration.test.util.User
 import com.gu.identity.integration.test.util.User._
 import com.gu.integration.test.steps.BaseSteps
+import com.gu.integration.test.util.PageLoader
 import com.gu.integration.test.util.UserConfig._
 import org.openqa.selenium.WebDriver
 import org.scalatest.EitherValues
@@ -21,6 +22,14 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       validationErrors.size should be(2)
 
       validationErrors.exists(_.errorText.contains("username")) should be (right = true)
+    }
+
+    scenarioWeb("should be able to go back to return URL after registration") { implicit driver: WebDriver =>
+      val subPath = "/sport"
+      val expectedReturnUrl = PageLoader.turnOfPopups(PageLoader.frontsBaseUrl + subPath)
+      UserSteps().createRandomBasicUser(Some(subPath)).right.value
+      val emailVerificationPage = new EmailVerificationPage()
+      UserSteps().checkUserGotCorrectReturnUrl(emailVerificationPage, expectedReturnUrl)
     }
 
     scenarioWeb("should be able to change email address", CoreTest) { implicit driver: WebDriver =>

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/UserSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/UserSteps.scala
@@ -23,10 +23,11 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
     profileNavMenu.clickEditProfile()
   }
 
-  def createRandomBasicUser(): Either[List[FormError], User] = {
+  def createRandomBasicUser(returnUrl: Option[String] = None): Either[List[FormError], User] = {
     logger.step("Creating random user")
-    BaseSteps().goToStartPage(useBetaRedirect = false)
+    BaseSteps().goToStartPage(useBetaRedirect = false, returnUrl)
     val registerPage = SignInSteps().clickSignInLink().clickRegisterNewUserLink()
+
     val userOrFormErrors = RegisterSteps().registerNewTempUser(registerPage)
     userOrFormErrors
   }
@@ -146,6 +147,10 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
 
   def checkUserGotPasswordResetSentMessage(passwordResetSentPage: PasswordResetSentPage) = {
     passwordResetSentPage.getMessageText() should be ("Now check your email")
+  }
+
+  def checkUserGotCorrectReturnUrl(emailVerificationPage: EmailVerificationPage, returnUrl: String) = {
+    emailVerificationPage.getCompleteRegistrationButtonLink should be (returnUrl)
   }
 
 }


### PR DESCRIPTION
Add test to ensure that if you go through registration from a sub page e.g. /uk/sport, you end up on the same page when you press "Complete Registration".