### PR TITLE
Stabilise social network tests

### DIFF
--- a/common-test-lib/src/main/scala/com/gu/integration/test/pages/common/ParentPage.scala
+++ b/common-test-lib/src/main/scala/com/gu/integration/test/pages/common/ParentPage.scala
@@ -1,12 +1,16 @@
 package com.gu.integration.test.pages.common
 
 import com.gu.automation.support.TestLogging
-import com.gu.integration.test.util.ElementLoader._
-import org.openqa.selenium.{WebElement, WebDriver}
+import org.openqa.selenium.{By, WebDriver}
+import org.openqa.selenium.support.ui.{ExpectedConditions, WebDriverWait}
 
 /**
  * This is a parent class for all Page Objects and does both pull in some traits, most importantly the PageHelper, so that
  * not all concrete page objects need to do it explicitly. And also contains elements present on all pages.
  */
 class ParentPage(implicit driver: WebDriver) extends TestLogging {
+  def waitForPageToLoad = {  //removes some test instability by forcing the page to load first
+    val wait = new WebDriverWait(driver, 10)
+    wait.until(ExpectedConditions.visibilityOfElementLocated(By.tagName("html")))
+  }
 }

--- a/identity-tests/src/main/resources/project.conf
+++ b/identity-tests/src/main/resources/project.conf
@@ -1,4 +1,4 @@
-"browsers": [{"name": "firefox", "version": "30"}, {"name": "chrome", "version": "35"}]
+"browsers": [{"name": "firefox"}, {"name": "chrome"}]
 
 "environment": "sauceLabs" //value of sauceLabs or browserStack will use the corresponding object below for picking up values
 

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EditAccountDetailsModule.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EditAccountDetailsModule.scala
@@ -71,15 +71,15 @@ class EditAccountDetailsModule(implicit driver: WebDriver) extends UserFormPage 
 
   //The reason for these seemingly uneccessary getters is because there is some principle which says you cannot expose
   //web elements directly
-  def getEmailAddress() = {
+  def getEmailAddress = {
     emailField.getAttribute("value")
   }
 
-  def getFirstName() = {
+  def getFirstName = {
     firstNameField.getText
   }
 
-  def getLastName() = {
+  def getLastName = {
     lastNameField.getText
   }
 

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EditProfilePage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EditProfilePage.scala
@@ -29,9 +29,9 @@ class EditProfilePage(implicit driver: WebDriver) extends ParentPage {
     new EditAccountDetailsModule()
   }
 
-  def getHeaderText(): Option[String] = {
+  def getHeaderText: Option[String] = {
     pageHeader match {
-      case Some(element: WebElement) => Some(element.getText())
+      case Some(element: WebElement) => Some(element.getText)
       case None => None
     }
   }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EmailVerificationPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/EmailVerificationPage.scala
@@ -2,14 +2,13 @@ package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.pages.common.ParentPage
 import com.gu.integration.test.util.ElementLoader._
-import org.openqa.selenium.support.ui.{ExpectedConditions, WebDriverWait}
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{WebDriver, WebElement}
 
 class EmailVerificationPage(implicit driver: WebDriver) extends ParentPage {
   private def completeRegistrationButton: WebElement = findByDataLinkAttribute("Continue")
 
   def getCompleteRegistrationButtonLink: String = {
-    new WebDriverWait(driver, 10).until(ExpectedConditions.presenceOfElementLocated(By.tagName("html")))
+    waitForPageToLoad
     completeRegistrationButton.getAttribute("href")
   }
 

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FaceBookAuthDialog.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FaceBookAuthDialog.scala
@@ -6,33 +6,35 @@ import org.openqa.selenium.{By, WebDriver, WebElement}
 
 class FaceBookAuthDialog(implicit driver: WebDriver) extends ParentPage {
 
-  private def confirmButton: WebElement = {
+  private def confirmButton: WebElement = {  //TODO investigate instability around this element
     val xpath = "id('platformDialogForm')//button[@name='__CONFIRM__']"
-    val wait = new WebDriverWait(driver, 10);
+    val wait = new WebDriverWait(driver, 10)
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)))
     driver.findElement(By.xpath(xpath))
   }
 
   private def editInformationProvided: WebElement = {
     val id = "u_0_l"
-    val wait = new WebDriverWait(driver, 10);
+    val wait = new WebDriverWait(driver, 10)
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(id)))
     driver.findElement(By.id(id))
   }
 
   private def emailCheckBox: WebElement = {
     val xpath = "(//span[preceding::input[@value='email']])[1]"
-    val wait = new WebDriverWait(driver, 20);
+    val wait = new WebDriverWait(driver, 20)
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)))
     driver.findElement(By.xpath(xpath))
   }
 
-  def clickConfirmButton() = {
+  def clickConfirmButton(email : String, pwd : String) = {
+    userSignedInToFacebook(email, pwd) //workaround
     confirmButton.click()
     new FrontPage()
   }
 
-  def clickEditInformationProvided() = {
+  def clickEditInformationProvided(email : String, pwd : String) = {
+    userSignedInToFacebook(email, pwd) //workaround
     editInformationProvided.click()
     this
   }
@@ -40,5 +42,14 @@ class FaceBookAuthDialog(implicit driver: WebDriver) extends ParentPage {
   def clickEmailCheckBox() = {
     emailCheckBox.click()
     this
+  }
+
+  def userSignedInToFacebook(email: String, pwd: String) = {
+    //Work around for tests where facebook sign in is not remembered
+    if (driver.getCurrentUrl contains "facebook.com/login.php") {
+      driver.findElement(By.id("email")).sendKeys(email)
+      driver.findElement(By.id("pass")).sendKeys(pwd)
+      driver.findElement(By.id("u_0_2")).click()
+    }
   }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FaceBookAuthDialog.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FaceBookAuthDialog.scala
@@ -36,6 +36,7 @@ class FaceBookAuthDialog(implicit driver: WebDriver) extends ParentPage {
   def clickEditInformationProvided(email: String, pwd: String) = {
     userSignedInToFacebook(email, pwd) //workaround
     editInformationProvided.click()
+    waitForPageToLoad
     this
   }
 

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FaceBookAuthDialog.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FaceBookAuthDialog.scala
@@ -6,7 +6,7 @@ import org.openqa.selenium.{By, WebDriver, WebElement}
 
 class FaceBookAuthDialog(implicit driver: WebDriver) extends ParentPage {
 
-  private def confirmButton: WebElement = {  //TODO investigate instability around this element
+  private def confirmButton: WebElement = {
     val xpath = "id('platformDialogForm')//button[@name='__CONFIRM__']"
     val wait = new WebDriverWait(driver, 10)
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)))
@@ -27,13 +27,13 @@ class FaceBookAuthDialog(implicit driver: WebDriver) extends ParentPage {
     driver.findElement(By.xpath(xpath))
   }
 
-  def clickConfirmButton(email : String, pwd : String) = {
+  def clickConfirmButton(email: String, pwd: String) = {
     userSignedInToFacebook(email, pwd) //workaround
     confirmButton.click()
     new FrontPage()
   }
 
-  def clickEditInformationProvided(email : String, pwd : String) = {
+  def clickEditInformationProvided(email: String, pwd: String) = {
     userSignedInToFacebook(email, pwd) //workaround
     editInformationProvided.click()
     this
@@ -46,6 +46,7 @@ class FaceBookAuthDialog(implicit driver: WebDriver) extends ParentPage {
 
   def userSignedInToFacebook(email: String, pwd: String) = {
     //Work around for tests where facebook sign in is not remembered
+    waitForPageToLoad
     if (driver.getCurrentUrl contains "facebook.com/login.php") {
       driver.findElement(By.id("email")).sendKeys(email)
       driver.findElement(By.id("pass")).sendKeys(pwd)

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookConfirmPasswordDialog.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookConfirmPasswordDialog.scala
@@ -7,14 +7,14 @@ import org.openqa.selenium.{By, WebDriver, WebElement}
 class FacebookConfirmPasswordDialog(implicit driver: WebDriver) extends ParentPage {
   private def continueButton: WebElement = {
     val cssSelector = "#u_0_0"
-    val wait = new WebDriverWait(driver, 10);
+    val wait = new WebDriverWait(driver, 10)
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(cssSelector)))
     driver.findElement(By.cssSelector(cssSelector))
   }
 
   private def confirmPasswordField: WebElement = {
     val xpath = "//input[@type='password']"
-    val wait = new WebDriverWait(driver, 10);
+    val wait = new WebDriverWait(driver, 10)
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath(xpath)))
     driver.findElement(By.xpath(xpath))
   }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookParentPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FacebookParentPage.scala
@@ -1,7 +1,6 @@
 package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.pages.common.ParentPage
-import com.gu.integration.test.util.ElementLoader._
 import org.openqa.selenium.{By, WebDriver, WebElement}
 
 class FacebookParentPage(implicit driver: WebDriver) extends ParentPage {

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FrontPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/FrontPage.scala
@@ -5,22 +5,22 @@ import org.openqa.selenium.{WebElement, By, WebDriver}
 
 class FrontPage(implicit driver: WebDriver) extends ContainerWithSigninModulePage {
 
-  private def getSiteMessage(): Option[WebElement] =  {
+  private def getSiteMessage: Option[WebElement] =  {
     try {
       val xpath = "//p[@class='site-message__message']"
       val wait = new WebDriverWait(driver, 15)
       wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath(xpath)))
       Some(driver.findElement(By.xpath(xpath)))
     } catch {
-      case _ => None
+      case _: Throwable => None
     }
   }
 
 
-  def getSiteMessageText(): Option[String] =
+  def getSiteMessageText: Option[String] =
   {
-    getSiteMessage() match {
-      case Some(element: WebElement) => Some(element.getText())
+    getSiteMessage match {
+      case Some(element: WebElement) => Some(element.getText)
       case None => None
     }
   }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/GoogleSignInPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/GoogleSignInPage.scala
@@ -18,4 +18,9 @@ class GoogleSignInPage(implicit driver: WebDriver) extends ParentPage {
     pwdInputField.sendKeys(pwd)
     this
   }
+
+  def clickLogInButton = {
+    loginInButton.click()
+    waitForPageToLoad // workaround to stabilise too rapid selenium actions
+  }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/PasswordResetConfirmationPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/PasswordResetConfirmationPage.scala
@@ -7,7 +7,7 @@ import org.openqa.selenium.{WebDriver, WebElement}
 class PasswordResetConfirmationPage(implicit driver: WebDriver) extends ContainerWithSigninModulePage {
   private def confirmation: WebElement = findByTestAttribute("password-reset-confirmation")
 
-  def isPasswordChangeMsgDisplayed(): Boolean = {
+  def isPasswordChangeMsgDisplayed: Boolean = {
     waitUntil(visibilityOf(confirmation))
   }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/PasswordResetSentPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/PasswordResetSentPage.scala
@@ -8,7 +8,7 @@ class PasswordResetSentPage(implicit driver: WebDriver) extends ContainerWithSig
     driver.findElement(By.cssSelector(".identity-title"))
   }
 
- def getMessageText(): String = {
+ def getMessageText: String = {
   message.getText
  }
 

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
@@ -52,6 +52,7 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
 
   def clickRegisterWithFacebookButton(): FaceBookAuthDialog = {
     //workaround for stale element caused by jittery javascript
+    waitForPageToLoad
     var count: Int = 0
     while (count < 4) {
       try {

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
@@ -2,7 +2,7 @@ package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.util.ElementLoader._
 import com.gu.integration.test.util.WebElementEnhancer._
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{StaleElementReferenceException, By, WebDriver, WebElement}
 
 class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
   private def emailInputField: WebElement = findByTestAttribute("reg-email")
@@ -51,9 +51,18 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
   }
 
   def clickRegisterWithFacebookButton(): FaceBookAuthDialog = {
-//    driver.asInstanceOf[JavascriptExecutor].executeScript("arguments[0].scrollIntoView(true);", registerWithFacebookButton); //workaround for large ads
-//    Thread sleep 500
-    registerWithFacebookButton.click()
+    //workaround for stale element caused by jittery javascript
+    var count: Int = 0
+    while (count < 4) {
+      try {
+        registerWithFacebookButton.click()
+        count = 4
+      } catch {
+        case e: StaleElementReferenceException => logger.error("stale element: " + "facebook-sign-in" + " for register with Facebook button")
+      }
+      count = count + 1
+    }
+
     new FaceBookAuthDialog()
   }
 
@@ -62,9 +71,9 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
     this
   }
 
-  def getFormErrorText(): Option[String] = {
+  def getFormErrorText: Option[String] = {
     try {
-      Some(driver.findElement(By.xpath("//div[@class='form__error']")).getText())
+      Some(driver.findElement(By.xpath("//div[@class='form__error']")).getText)
     } catch {
       case _: org.openqa.selenium.NoSuchElementException => None
     }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInModule.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInModule.scala
@@ -30,6 +30,7 @@ class SignInModule(implicit driver: WebDriver) extends ParentPage {
 
   def clickSignInLink(): SignInPage = {
     new Actions(driver).moveToElement(signInLink).perform()
+    waitForPageToLoad
     var count: Int = 0
     while (count < 4) {
       try {
@@ -40,11 +41,13 @@ class SignInModule(implicit driver: WebDriver) extends ParentPage {
       }
       count = count + 1
     }
+    waitForPageToLoad
     new SignInPage()
   }
 
   def clickSignInLinkWhenLoggedIn(): ProfileNavMenu = {
     //workaround for stale element caused by jittery javascript
+    waitForPageToLoad
     var count: Int = 0
     while (count < 4) {
       try {
@@ -55,7 +58,7 @@ class SignInModule(implicit driver: WebDriver) extends ParentPage {
       }
       count = count + 1
     }
-
+    waitForPageToLoad
     new ProfileNavMenu
   }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInModule.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInModule.scala
@@ -3,25 +3,59 @@ package com.gu.identity.integration.test.pages
 import com.gu.integration.test.pages.common.ParentPage
 import com.gu.integration.test.util.ElementLoader._
 import org.openqa.selenium.interactions.Actions
-import org.openqa.selenium.{WebDriver, WebElement}
+import org.openqa.selenium.{StaleElementReferenceException, WebDriver, WebElement}
 
 /**
  * Do not confuse this with the sign in page. This is only the module which sits at the top of most frontend pages
  */
 class SignInModule(implicit driver: WebDriver) extends ParentPage {
   private def signInLink: WebElement = findByTestAttribute("sign-in-link")
+
   def signInName: WebElement = findByTestAttribute("sign-in-name")
+
+  def getSignInName: String = {
+    var count: Int = 0
+    var name: String = ""
+    while (count < 4) {
+      try {
+        name = signInName.getText
+        count = 4
+      } catch {
+        case e: StaleElementReferenceException => logger.error("stale element: " + "sign-in-link" + " for sign in module")
+      }
+      count = count + 1
+    }
+    name
+  }
 
   def clickSignInLink(): SignInPage = {
     new Actions(driver).moveToElement(signInLink).perform()
-    signInLink.click()
+    var count: Int = 0
+    while (count < 4) {
+      try {
+        signInLink.click()
+        count = 4
+      } catch {
+        case e: StaleElementReferenceException => logger.error("stale element: " + "sign-in-link" + " for sign in module")
+      }
+      count = count + 1
+    }
     new SignInPage()
   }
 
   def clickSignInLinkWhenLoggedIn(): ProfileNavMenu = {
-    val y = signInLink.getLocation
- //   driver.asInstanceOf[JavascriptExecutor].executeScript(s"window.scrollTo(0, $y)") //workaround for large ads
-    signInLink.click()
+    //workaround for stale element caused by jittery javascript
+    var count: Int = 0
+    while (count < 4) {
+      try {
+        signInLink.click()
+        count = 4
+      } catch {
+        case e: StaleElementReferenceException => logger.error("stale element: " + "sign-in-link" + " for sign in module")
+      }
+      count = count + 1
+    }
+
     new ProfileNavMenu
   }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
@@ -6,7 +6,6 @@ import org.openqa.selenium.support.ui.ExpectedConditions._
 import org.openqa.selenium.{By, WebDriver, WebElement}
 
 class SignInPage(implicit driver: WebDriver) extends ParentPage {
-
   private def emailInputField: WebElement = findByTestAttribute("signin-email")
   private def pwdInputField: WebElement = findByTestAttribute("signin-pwd")
   def signInButton: WebElement = findByTestAttribute("sign-in-button")
@@ -45,16 +44,10 @@ class SignInPage(implicit driver: WebDriver) extends ParentPage {
     new GoogleSignInPage()
   }
 
-// removed function as idSocialOauth switch has been removed
-//  def ensureOauthActive() = {
-//    if (driver.getCurrentUrl().contains("code")) {
-//      // with the move to the centralised configuration we need to check that we are testing the correct API
-//      val oauthActive = driver.asInstanceOf[JavascriptExecutor].executeScript("return guardian.config.switches.idSocialOauth")
-//      if (!oauthActive.asInstanceOf[Boolean]) {
-//        throw new RuntimeException("Federation API not active")
-//      }
-//    }
-//  }
+  def clickSignInWithFaceBookNoEmail = {
+    clickResignInWithFacebook
+    new RegisterPage()
+  }
 
   def clickRegisterNewUserLink(): RegisterPage = {
     registerLink.click()

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
@@ -32,16 +32,6 @@ class SignInPage(implicit driver: WebDriver) extends ParentPage with ThirdPartyC
     new FaceBookSignInPage()
   }
 
-  def clickResignInWithFacebook = {
-    faceBookSignInButton.click()
-    this
-  }
-
-  def clickGoogleSignInButton(): GoogleSignInPage = {
-    googleSignInButton.click()
-    new GoogleSignInPage()
-  }
-
   def clickSignInWithFaceBookNoEmail = {
     clickResignInWithFacebook
     new RegisterPage()

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/UserFormPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/UserFormPage.scala
@@ -12,7 +12,7 @@ class UserFormPage(implicit driver: WebDriver) extends ParentPage {
 
   private def validationErrors: List[WebElement] = findAllByTestAttribute("form-field-error")
 
-  def getAllValidationFormErrors(): List[FormError] = {
+  def getAllValidationFormErrors: List[FormError] = {
     val errorElements = displayedElements(validationErrors, 1)
     errorElements.map(webElement => FormError(webElement.getText))
   }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/tags/Tags.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/tags/Tags.scala
@@ -23,3 +23,6 @@ import org.scalatest.Tag
   //test is important but the site can handle this feature missing for a short time
   object OptionalTest extends Tag("OptionalTest")
 
+  //test is specifically testing the interaction with external social applications
+  object SocialTest extends Tag("SocialTest")
+

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/util/facebook/FacebookTestUserService.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/util/facebook/FacebookTestUserService.scala
@@ -93,7 +93,7 @@ object FacebookTestUserService {
       Some(createdFacebookTestUser.id),
       Some(createdFacebookTestUser.email),
       Some(createdFacebookTestUser.login_url),
-      true
+      created = true
     )
 
     mergedFacebookTestUser

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/LoginTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/LoginTests.scala
@@ -3,7 +3,7 @@ package com.gu.identity.integration.test.features
 import com.gu.automation.support.Config
 import com.gu.identity.integration.test.IdentitySeleniumTestSuite
 import com.gu.identity.integration.test.steps.SignInSteps
-import com.gu.identity.integration.test.tags.{OptionalTest, CoreTest}
+import com.gu.identity.integration.test.tags.{SocialTest, OptionalTest, CoreTest}
 import com.gu.integration.test.steps.BaseSteps
 import com.gu.integration.test.util.UserConfig._
 import org.openqa.selenium.WebDriver
@@ -11,21 +11,23 @@ import org.openqa.selenium.WebDriver
 class LoginTests extends IdentitySeleniumTestSuite {
 
   feature("Login feature") {
-    scenarioWeb("should be able to login using credentials", CoreTest) { implicit driver: WebDriver =>
+    scenarioWeb("L1: should be able to login using credentials", CoreTest) { implicit driver: WebDriver =>
       BaseSteps().goToStartPage()
       SignInSteps().signIn()
       SignInSteps().checkUserIsLoggedIn(get("loginName"))
       SignInSteps().checkUserIsLoggedInSecurely()
     }
 
-    scenarioWeb("should be able to login using existing Facebook account", OptionalTest) { implicit driver: WebDriver =>
+    scenarioWeb("L2: should be able to login using existing Facebook account", OptionalTest, SocialTest) {
+      implicit driver: WebDriver =>
       BaseSteps().goToStartPage()
       SignInSteps().signInUsingFaceBook()
       SignInSteps().checkUserIsLoggedIn(Config().getUserValue("faceBookLoginName"))
       SignInSteps().checkUserIsLoggedInSecurely()
     }
 
-    scenarioWeb("should be able to login using existing Google account", OptionalTest) { implicit driver: WebDriver =>
+    scenarioWeb("L3: should be able to login using existing Google account", OptionalTest, SocialTest) {
+      implicit driver: WebDriver =>
       BaseSteps().goToStartPage()
       SignInSteps().signInUsingGoogle()
       SignInSteps().checkUserIsLoggedIn(Config().getUserValue("googleLoginName"))

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -6,7 +6,7 @@ import com.gu.identity.integration.test.steps.{SignInSteps, SocialNetworkSteps, 
 import com.gu.identity.integration.test.tags.{CoreTest, OptionalTest, SocialTest}
 import com.gu.identity.integration.test.util.facebook.FacebookTestUser
 import com.gu.integration.test.steps.BaseSteps
-import org.openqa.selenium.WebDriver
+import org.openqa.selenium.{JavascriptExecutor, WebDriver}
 import org.scalatest.Tag
 
 
@@ -146,6 +146,7 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
       implicit driver: WebDriver =>
         BaseSteps().goToStartPage()
         SignInSteps().signInUsingGoogle()
+        driver.asInstanceOf[JavascriptExecutor].executeScript("javascript:window.scrollTop") //chrome browser flicks user down to content after signing in with Google+ so scroll back to top
         val editAccountDetailsPage = UserSteps().goToEditProfilePage(new ContainerWithSigninModulePage())
         SocialNetworkSteps().checkUserGotReAuthenticationMessage(editAccountDetailsPage)
         val googleConfirmPasswordDialog = editAccountDetailsPage.clickConfirmWithGoogleButton

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -112,7 +112,7 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
         SignInSteps().clickSignInWithFacebook()
 
         BaseSteps().goToStartPage()
-        SignInSteps().checkUserIsLoggedIn(facebookUser.fullName) //TODO invesigate failure to sign in
+        SignInSteps().checkUserIsLoggedIn(facebookUser.fullName) //TODO investigate failure to sign in
         BaseSteps().goToStartPage()
         val signInEmail = UserSteps().goToEditAccountPage(new ContainerWithSigninModulePage())
           .clickEditAccountDetailsTab().getEmailAddress
@@ -138,7 +138,7 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
         val requestPermissionsDialog = new FaceBookAuthDialog()
         requestPermissionsDialog.clickConfirmButton(facebookUser.email.get, facebookUser.password.get)
         BaseSteps().goToStartPage()
-        SignInSteps().checkUserIsLoggedIn(facebookUser.fullName)  //TODO invesigate failure to sign in
+        SignInSteps().checkUserIsLoggedIn(facebookUser.fullName)  //TODO investigate failure to sign in
     }
 
   }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsOfServiceTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsOfServiceTests.scala
@@ -1,14 +1,14 @@
 package com.gu.identity.integration.test.features
 
 import com.gu.identity.integration.test.IdentitySeleniumTestSuite
-import com.gu.identity.integration.test.tags.Unstable
+import com.gu.identity.integration.test.tags.OptionalTest
 import com.gu.integration.test.steps.BaseSteps
 import org.openqa.selenium.WebDriver
 
 class TermsOfServiceTests extends IdentitySeleniumTestSuite {
 
   feature("Terms of Service feature") {
-    scenarioWeb("should not be empty or trivial", Unstable) { implicit driver: WebDriver =>
+    scenarioWeb("TOS1:  should not be empty or trivial", OptionalTest) { implicit driver: WebDriver =>
       val tosPage = BaseSteps().goToTermsOfServicePage()
       val minimumTosContentSize = 100
       val tosContent: String = tosPage.getContent()

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
@@ -16,12 +16,12 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
 
   feature("Create and changing a User") {
 
-    scenarioWeb("should not be able to create user with existing user name", CoreTest) { implicit driver: WebDriver =>
+    scenarioWeb("U1: should not be able to create user with existing user name", CoreTest) { implicit driver: WebDriver =>
       val validationErrors : List[FormError] = UserSteps().createUserWithUserName(get("loginName")).left.value
       validationErrors should contain (FormError("This username has already been taken"))
     }
 
-    scenarioWeb("should be able to change email address", CoreTest) { implicit driver: WebDriver =>
+    scenarioWeb("U2: should be able to change email address", CoreTest) { implicit driver: WebDriver =>
       val userBeforeChange: User = UserSteps().createRandomBasicUser().right.value
       val editAccountDetailsModule = UserSteps().checkUserIsLoggedInAndGoToAccountDetails(userBeforeChange)
 
@@ -38,7 +38,7 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       validationErrors.head.errorText.contains("email") should be(right = true)
     }
 
-    scenarioWeb("should be able to set and change first and last name", OptionalTest) { implicit driver: WebDriver =>
+    scenarioWeb("U3: should be able to set and change first and last name", OptionalTest) { implicit driver: WebDriver =>
       val userBeforeChange: User = UserSteps().createRandomBasicUser().right.value
       val editAccountDetailsModule = UserSteps().checkUserIsLoggedInAndGoToAccountDetails(userBeforeChange)
 
@@ -48,7 +48,7 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       userWithChangedName.lastName should not be userBeforeChange.lastName
     }
 
-    scenarioWeb("should be able to set and change address", OptionalTest) { implicit driver: WebDriver =>
+    scenarioWeb("U4: should be able to set and change address", OptionalTest) { implicit driver: WebDriver =>
       val userBeforeChange: User = UserSteps().createRandomBasicUser().right.value
       val editAccountDetailsModule = UserSteps().checkUserIsLoggedInAndGoToAccountDetails(userBeforeChange)
 
@@ -62,7 +62,7 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       userWithChangedAddress.country should not be userBeforeChange.country
     }
 
-    scenarioWeb("should be able to change password", CoreTest) { implicit driver: WebDriver =>
+    scenarioWeb("U5: should be able to change password", CoreTest) { implicit driver: WebDriver =>
       val userBeforeChange: User = UserSteps().createRandomBasicUser().right.value
       val containerWithSignInModulePage = SignInSteps().checkUserIsLoggedIn(userBeforeChange)
 
@@ -77,7 +77,7 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       SignInSteps().checkUserIsLoggedIn(userBeforeChange.userName)
     }
 
-    scenarioWeb("should be able to reset password", CoreTest) { implicit driver: WebDriver =>
+    scenarioWeb("U6: should be able to reset password", CoreTest) { implicit driver: WebDriver =>
       BaseSteps().goToStartPage()
       SignInSteps().signInUsingFaceBook()
       val passwordResetSentPage = UserSteps().requestToResetPassword(new ContainerWithSigninModulePage())

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.integration.test.steps
 
 import com.gu.automation.support.{Config, CookieManager, TestLogging}
-import com.gu.identity.integration.test.pages.{ContainerWithSigninModulePage, RegisterPage, SignInPage}
+import com.gu.identity.integration.test.pages._
 import com.gu.identity.integration.test.util.User
 import com.gu.integration.test.steps.BaseSteps
 import com.gu.integration.test.util.CookieUtil._
@@ -65,10 +65,10 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
     faceBookSignInPage.loginInButton.click()
   }
 
-  def clickSignInWithFacebook(emailAllowed: Boolean = true): Either[SignInPage, RegisterPage] = {
+  def clickSignInWithFacebook(emailAllowed: Boolean = true): Either[FaceBookSignInPage, RegisterPage] = {
     //user sent down either path if the user has allowed the email or not
     if (emailAllowed) {
-      Left(new SignInPage().clickResignInWithFacebook)
+      Left(new SignInPage().clickFaceBookSignInButton())
     } else {
       Right(new SignInPage().clickSignInWithFaceBookNoEmail)
     }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -90,7 +90,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
     googleSignInPage.enterEmail(Config().getUserValue("googleEmail"))
     googleSignInPage.nextButton.click()
     googleSignInPage.enterPwd(Config().getUserValue("googlePwd"))
-    googleSignInPage.loginInButton.click()
+    googleSignInPage.clickLogInButton
   }
 
   def signOut(pageWithSignInModule: ContainerWithSigninModulePage) = {

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -43,7 +43,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
 
   def checkUserIsLoggedIn(expectedLoginName: String) = {
     logger.step(s"Checking that user is logged in")
-    val loginName = new ContainerWithSigninModulePage().signInModule().signInName.getText
+    val loginName = new ContainerWithSigninModulePage().signInModule().getSignInName
     loginName should include (expectedLoginName)
 
     val loginCookie = getCookie(LoginCookie)

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.integration.test.steps
 
-import com.gu.automation.support.{CookieManager, Config, TestLogging}
-import com.gu.identity.integration.test.pages.{ContainerWithSigninModulePage, SignInPage}
+import com.gu.automation.support.{Config, CookieManager, TestLogging}
+import com.gu.identity.integration.test.pages.{ContainerWithSigninModulePage, RegisterPage, SignInPage}
 import com.gu.identity.integration.test.util.User
 import com.gu.integration.test.steps.BaseSteps
 import com.gu.integration.test.util.CookieUtil._
@@ -26,7 +26,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
     signInWith(Config().getLoginEmail(), Config().getLoginPassword())
   }
 
-  def signInWith(email:String, pwd:String) = {
+  def signInWith(email: String, pwd: String) = {
     logger.step("Signing in using credentials")
     val signInPage = SignInSteps().clickSignInLink()
     signInPage.enterEmail(email)
@@ -44,7 +44,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   def checkUserIsLoggedIn(expectedLoginName: String) = {
     logger.step(s"Checking that user is logged in")
     val loginName = new ContainerWithSigninModulePage().signInModule().getSignInName
-    loginName should include (expectedLoginName)
+    loginName should include(expectedLoginName)
 
     val loginCookie = getCookie(LoginCookie)
     loginCookie.getValue should not be empty
@@ -65,9 +65,13 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
     faceBookSignInPage.loginInButton.click()
   }
 
-  def clickSignInWithFacebook() = {
-    new SignInPage().clickResignInWithFacebook
-    this
+  def clickSignInWithFacebook(emailAllowed: Boolean = true): Either[SignInPage, RegisterPage] = {
+    //user sent down either path if the user has allowed the email or not
+    if (emailAllowed) {
+      Left(new SignInPage().clickResignInWithFacebook)
+    } else {
+      Right(new SignInPage().clickSignInWithFaceBookNoEmail)
+    }
   }
 
   def signInUsingNewFaceBook() = {
@@ -100,7 +104,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
     loginName should not be expectedLoginName
 
     val loginCookie = getCookie(LoginCookie)
-    loginCookie should be (null)
+    loginCookie should be(null)
   }
 
   def clearLoginCookies() = {

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SocialNetworkSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SocialNetworkSteps.scala
@@ -1,4 +1,4 @@
-package com.gu.integration.test.steps
+package com.gu.identity.integration.test.steps
 
 import com.gu.automation.support.{Config, LocalStorageManager, TestLogging}
 import com.gu.identity.integration.test.pages.{EditProfilePage, FacebookParentPage, FrontPage, RegisterPage}
@@ -32,43 +32,42 @@ case class SocialNetworkSteps(implicit driver: WebDriver) extends TestLogging wi
     facebookSignInPage.enterEmail(facebookTestUser.email.get)
     facebookSignInPage.enterPassword(facebookTestUser.password.get)
     facebookSignInPage.clickLoginButton()
-
     facebookSignInPage
   }
 
   def checkUserGotFacebookEmailError(registerPage: RegisterPage) = {
-    registerPage.getFormErrorText() match {
-      case Some(errorMessage: String) => errorMessage should include ("allow access to your email address")
+    registerPage.getFormErrorText match {
+      case Some(errorMessage: String) => errorMessage should include("allow access to your email address")
       case None => fail("Did not get Facebook e-mail error message")
     }
   }
 
   def checkUserGotAutoSignInBanner(frontPage: FrontPage) = {
-    frontPage.getSiteMessageText() match {
-      case Some(text: String) => text should include ("signed in to the Guardian using Facebook")
+    frontPage.getSiteMessageText match {
+      case Some(text: String) => text should include("signed in to the Guardian using Facebook")
       case _ => fail("Did not get auto sign in banner")
     }
   }
 
   def checkUserGotReAuthenticationMessage(editProfilePage: EditProfilePage) = {
     logger.step("Check that user got asked to re-authenticate")
-    editProfilePage.getHeaderText() match {
-      case Some(text: String) => text should be ("Confirm your identity")
+    editProfilePage.getHeaderText match {
+      case Some(text: String) => text should be("Confirm your identity")
       case _ => fail("Did not get asked to re-authenticate")
     }
   }
 
   def checkUserIsOnEditProfilePage(editProfilePage: EditProfilePage) = {
     logger.step("Check that user is on edit profile page")
-    editProfilePage.getHeaderText() match {
-      case Some(text: String) => text should be ("Edit your profile")
+    editProfilePage.getHeaderText match {
+      case Some(text: String) => text should be("Edit your profile")
       case _ => fail("Is not on edit profile page")
     }
   }
 
   def checkUserIsOnFacebook() = {
     val facebookUrl = "^https://www.facebook.com/(.*)$".r
-    driver.getCurrentUrl() match {
+    driver.getCurrentUrl match {
       case facebookUrl(c) => logger.step("User is on Facebook")
       case _ => fail("User is not on Facebook")
     }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/UserSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/UserSteps.scala
@@ -5,8 +5,6 @@ import com.gu.identity.integration.test.pages._
 import com.gu.identity.integration.test.util.User._
 import com.gu.identity.integration.test.util.{FormError, User}
 import com.gu.integration.test.steps.BaseSteps
-import com.gu.integration.test.util.CookieUtil._
-import com.gu.integration.test.util.ElementLoader._
 import com.gu.integration.test.util.PageLoader._
 import com.gu.integration.test.util.UserConfig._
 import org.openqa.selenium.WebDriver
@@ -64,11 +62,11 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
 
     waitForPageToLoad
 
-    val userFormErrors = editAccountDetailsModule.getAllValidationFormErrors()
+    val userFormErrors = editAccountDetailsModule.getAllValidationFormErrors
     if (userFormErrors.nonEmpty) {
       Left(userFormErrors)
     } else {
-      Right(editAccountDetailsModule.getEmailAddress())
+      Right(editAccountDetailsModule.getEmailAddress)
     }
   }
 
@@ -80,7 +78,7 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
 
     waitForPageToLoad
 
-    editAccountDetailsModule.getAllValidationFormErrors() should be('empty)
+    editAccountDetailsModule.getAllValidationFormErrors should be('empty)
     User.fromEditAccountDetailsForm(editAccountDetailsModule)
   }
 
@@ -96,7 +94,7 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
 
     waitForPageToLoad
 
-    editAccountDetailsModule.getAllValidationFormErrors() should be('empty)
+    editAccountDetailsModule.getAllValidationFormErrors should be('empty)
     User.fromEditAccountDetailsForm(editAccountDetailsModule)
   }
 
@@ -121,8 +119,8 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
 
     waitForPageToLoad
 
-    changePwdPage.getAllValidationFormErrors() should be('empty)
-    resetConfirmPage.isPasswordChangeMsgDisplayed()
+    changePwdPage.getAllValidationFormErrors should be('empty)
+    resetConfirmPage.isPasswordChangeMsgDisplayed
 
     waitForPageToLoad
 
@@ -146,7 +144,7 @@ case class UserSteps(implicit driver: WebDriver) extends TestLogging with Matche
   }
 
   def checkUserGotPasswordResetSentMessage(passwordResetSentPage: PasswordResetSentPage) = {
-    passwordResetSentPage.getMessageText() should be ("Now check your email")
+    passwordResetSentPage.getMessageText should be ("Now check your email")
   }
 
   def checkUserGotCorrectReturnUrl(emailVerificationPage: EmailVerificationPage, returnUrl: String) = {


### PR DESCRIPTION
To improve the robustness of the tests I have added in some workarounds, namely:  
- try/catches around the elements that can become stale while the page is loading  
- If statement when going to facebook after facebook user is created to log the user in again if they are not logged in  

To help with clarifying which aspects of the tests are failing a new tag for social tests is included so that we can segment those tests out.  

Removed the version for firefox and chrome so that the latest versions are used since the current versions in the conf are out of date.  

While I was updating the files I also cleaned up some of the code, e.g. removing unnecessary ; or () or imports

After merging in master there is a bit of flickering with the Google+ sign in test.  In chrome browsers the page focuses on the first content item, scrolling the menu out of sight.  I have put a javascript statement in to scroll to the top.