### PR TITLE
Add tests for third party conditions

### DIFF
--- a/identity-tests/src/main/resources/project.conf
+++ b/identity-tests/src/main/resources/project.conf
@@ -29,3 +29,4 @@
   "googlePwd": ""
   "googleLoginName": "" //observe that guardian uses the facebook name if you use the same email for Google+ and Facebook signin
 }
+

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/AgreePage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/AgreePage.scala
@@ -1,0 +1,8 @@
+package com.gu.identity.integration.test.pages
+
+import com.gu.integration.test.pages.common.ParentPage
+import org.openqa.selenium.WebDriver
+
+class AgreePage(implicit  driver: WebDriver) extends ParentPage with ThirdPartyConditions {
+
+}

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/JobsStubPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/JobsStubPage.scala
@@ -1,0 +1,32 @@
+package com.gu.identity.integration.test.pages
+
+import com.gu.integration.test.pages.common.ParentPage
+import org.openqa.selenium.support.ui.ExpectedConditions._
+import org.openqa.selenium.{WebElement, WebDriver}
+import com.gu.integration.test.util.ElementLoader._
+
+class JobsStubPage(implicit  driver: WebDriver) extends ParentPage {
+
+  val loginLink: WebElement = findByDataLinkAttribute("Signin")
+  val registrationLink: WebElement = findByDataLinkAttribute("Register")
+
+  def clickLogin(): SignInPage = {
+    waitUntil(visibilityOf(loginLink), 10)
+    loginLink.click()
+    new SignInPage
+  }
+
+  def clickRegister(): RegisterPage = {
+    waitUntil(visibilityOf(loginLink), 10)
+    registrationLink.click()
+    new RegisterPage
+  }
+
+  def clickLoginAsExistingUser(): AgreePage = {
+    waitUntil(visibilityOf(loginLink), 10)
+    loginLink.click()
+    new AgreePage
+  }
+
+
+}

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
@@ -4,7 +4,7 @@ import com.gu.integration.test.util.ElementLoader._
 import com.gu.integration.test.util.WebElementEnhancer._
 import org.openqa.selenium.{By, WebDriver, WebElement}
 
-class RegisterPage(implicit driver: WebDriver) extends UserFormPage {
+class RegisterPage(implicit driver: WebDriver) extends UserFormPage with ThirdPartyConditions with SocialSignInButtons {
   private def emailInputField: WebElement = findByTestAttribute("reg-email")
 
   private def userNameInputField: WebElement = findByTestAttribute("reg-username")

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SignInPage.scala
@@ -5,13 +5,11 @@ import com.gu.integration.test.util.ElementLoader._
 import org.openqa.selenium.support.ui.ExpectedConditions._
 import org.openqa.selenium.{By, WebDriver, WebElement}
 
-class SignInPage(implicit driver: WebDriver) extends ParentPage {
+class SignInPage(implicit driver: WebDriver) extends ParentPage with ThirdPartyConditions with SocialSignInButtons {
 
   private def emailInputField: WebElement = findByTestAttribute("signin-email")
   private def pwdInputField: WebElement = findByTestAttribute("signin-pwd")
   def signInButton: WebElement = findByTestAttribute("sign-in-button")
-  private def faceBookSignInButton: WebElement = findByTestAttribute("facebook-sign-in")
-  private def googleSignInButton: WebElement = findByTestAttribute("google-sign-in")
   private def registerLink: WebElement = findByTestAttribute("register-link")
   private def faceBookEmailElement: WebElement = driver.findElement(By.name("email"))
 
@@ -33,16 +31,6 @@ class SignInPage(implicit driver: WebDriver) extends ParentPage {
     }
 
     new FaceBookSignInPage()
-  }
-
-  def clickResignInWithFacebook = {
-    faceBookSignInButton.click()
-    this
-  }
-
-  def clickGoogleSignInButton(): GoogleSignInPage = {
-    googleSignInButton.click()
-    new GoogleSignInPage()
   }
 
 // removed function as idSocialOauth switch has been removed

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SocialSignInButtons.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/SocialSignInButtons.scala
@@ -1,0 +1,29 @@
+package com.gu.identity.integration.test.pages
+
+import com.gu.integration.test.util.ElementLoader._
+import org.openqa.selenium.{WebDriver, WebElement}
+
+trait SocialSignInButtons {
+
+  private def faceBookSignInButton(implicit driver: WebDriver): WebElement = findByTestAttribute("facebook-sign-in")
+  private def googleSignInButton(implicit driver: WebDriver): WebElement = findByTestAttribute("google-sign-in")
+
+  def getFaceBookSignInLink(implicit driver: WebDriver): String = {
+    faceBookSignInButton.getAttribute("href")
+  }
+
+  def clickResignInWithFacebook(implicit driver: WebDriver) = {
+    faceBookSignInButton.click()
+    this
+  }
+
+  def clickGoogleSignInButton(implicit driver: WebDriver): GoogleSignInPage = {
+    googleSignInButton.click()
+    new GoogleSignInPage()
+  }
+
+  def getGoogleSignInLink(implicit driver: WebDriver): String = {
+    googleSignInButton.getAttribute("href")
+  }
+
+}

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/ThirdPartyConditions.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/ThirdPartyConditions.scala
@@ -1,0 +1,15 @@
+package com.gu.identity.integration.test.pages
+
+import com.gu.integration.test.util.ElementLoader._
+import org.openqa.selenium.{WebDriver, WebElement}
+
+trait ThirdPartyConditions {
+
+  private def jobsTC(implicit driver: WebDriver): WebElement = findByTestAttribute("jobs-tc")
+  private def jobsPrivacy(implicit driver: WebDriver): WebElement = findByTestAttribute("jobs-privacy")
+
+  def checkJobsTermsVisible(implicit driver: WebDriver): Boolean = {
+    jobsTC.isDisplayed && jobsPrivacy.isDisplayed
+  }
+
+}

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/util/UrlParamExtractor.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/util/UrlParamExtractor.scala
@@ -1,0 +1,31 @@
+package com.gu.identity.integration.test.util
+
+import java.net.URI
+
+import scala.util.Try
+
+object UrlParamExtractor {
+
+  def extractQueryParams(url: String): Map[String, String] =
+  {
+    def keyValuePair(queryParam: String): (String, String) = {
+      (queryParam.split("=")(0), Try(queryParam.split("=").tail.mkString("=")).toOption.getOrElse(""))
+    }
+
+    val uri = new URI(url)
+    Option(uri.getQuery) match {
+      case Some(query) => {
+        query.split("&").map(keyValuePair).map(p => p._1 -> p._2).toMap
+      }
+      case _ => Map()
+    }
+  }
+
+  def returnUrl(url: String): Option[URI] = {
+    extractQueryParams(url).get("returnUrl") match {
+      case Some(returnUrl) => Try(new URI(returnUrl)).toOption
+      case _ => None
+    }
+  }
+
+}

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsAndConditionsTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsAndConditionsTests.scala
@@ -1,0 +1,51 @@
+package com.gu.identity.integration.test.features
+
+import com.gu.identity.integration.test.IdentitySeleniumTestSuite
+import com.gu.identity.integration.test.steps.{UserSteps, SignInSteps, TermsAndConditionsSteps}
+import com.gu.identity.integration.test.tags.CoreTest
+import com.gu.identity.integration.test.util.{User, UrlParamExtractor}
+import com.gu.integration.test.steps.BaseSteps
+import org.openqa.selenium.WebDriver
+
+class TermsAndConditionsTests extends IdentitySeleniumTestSuite {
+
+
+  feature("T&C's feature") {
+    scenarioWeb("should be shown third party T&C's when logging-in from jobs", CoreTest) { implicit driver: WebDriver =>
+      val signinPage = TermsAndConditionsSteps().goToJobsSite.clickLogin()
+      TermsAndConditionsSteps().checkJobsTermsVisible(signinPage)
+    }
+
+    scenarioWeb("should be shown third party T&C's when registering from jobs", CoreTest) { implicit  driver: WebDriver =>
+      val registerPage = TermsAndConditionsSteps().goToJobsSite.clickRegister()
+      TermsAndConditionsSteps().checkJobsTermsVisible(registerPage)
+    }
+
+    scenarioWeb("should have agree page as return URL for Facebook sign in", CoreTest) { implicit driver: WebDriver =>
+      val signinPage = TermsAndConditionsSteps().goToJobsSite.clickLogin()
+      UrlParamExtractor.returnUrl(signinPage.getFaceBookSignInLink).get.getPath should be("/agree/GRS")
+    }
+
+    scenarioWeb("should have agree page as return URL for Google sign in", CoreTest) { implicit driver: WebDriver =>
+      val signinPage = TermsAndConditionsSteps().goToJobsSite.clickLogin()
+      UrlParamExtractor.returnUrl(signinPage.getGoogleSignInLink).get.getPath should be("/agree/GRS")
+    }
+
+    scenarioWeb("should have agree page as return URL for Facebook registration", CoreTest) { implicit driver: WebDriver =>
+      val registerPage = TermsAndConditionsSteps().goToJobsSite.clickRegister()
+      UrlParamExtractor.returnUrl(registerPage.getFaceBookSignInLink).get.getPath should be("/agree/GRS")
+    }
+
+    scenarioWeb("should have agree page as return URL for Google registration", CoreTest) { implicit driver: WebDriver =>
+      val registerPage = TermsAndConditionsSteps().goToJobsSite.clickRegister()
+      UrlParamExtractor.returnUrl(registerPage.getGoogleSignInLink).get.getPath should be("/agree/GRS")
+    }
+
+    scenarioWeb("should show third party T&C's to already logged in user", CoreTest) { implicit driver: WebDriver =>
+      val user: User = UserSteps().createRandomBasicUser().right.get
+      val agreePage = TermsAndConditionsSteps().goToJobsSite.clickLoginAsExistingUser()
+      TermsAndConditionsSteps().checkJobsTermsVisible(agreePage)
+    }
+  }
+
+}

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/SignInSteps.scala
@@ -82,7 +82,7 @@ case class SignInSteps(implicit driver: WebDriver) extends TestLogging with Matc
   def signInUsingGoogle() = {
     logger.step(s"Signing in using Google")
     val signInPage = SignInSteps().clickSignInLink()
-    val googleSignInPage = signInPage.clickGoogleSignInButton()
+    val googleSignInPage = signInPage.clickGoogleSignInButton
     googleSignInPage.enterEmail(Config().getUserValue("googleEmail"))
     googleSignInPage.nextButton.click()
     googleSignInPage.enterPwd(Config().getUserValue("googlePwd"))

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/TermsAndConditionsSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/TermsAndConditionsSteps.scala
@@ -1,0 +1,23 @@
+package com.gu.identity.integration.test.steps
+
+import com.gu.automation.support.TestLogging
+import com.gu.identity.integration.test.pages.{ThirdPartyConditions, JobsStubPage}
+import org.openqa.selenium.WebDriver
+import org.scalatest.Matchers
+
+case class TermsAndConditionsSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
+
+  val jobsStub = "http://public-jobs-thegulocal-com.s3-website-eu-west-1.amazonaws.com"
+
+  def goToJobsSite: JobsStubPage = {
+    logger.step(s"I am on stub jobs page at url: $jobsStub")
+    driver.navigate().to(jobsStub)
+    new JobsStubPage
+  }
+
+  def checkJobsTermsVisible(page: ThirdPartyConditions) = {
+    logger.step(s"Check that jobs T&C's are visible on page")
+    page.checkJobsTermsVisible should be(true)
+  }
+
+}

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/TermsAndConditionsSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/TermsAndConditionsSteps.scala
@@ -1,13 +1,13 @@
 package com.gu.identity.integration.test.steps
 
-import com.gu.automation.support.TestLogging
+import com.gu.automation.support.{Config, TestLogging}
 import com.gu.identity.integration.test.pages.{ThirdPartyConditions, JobsStubPage}
 import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
 
 case class TermsAndConditionsSteps(implicit driver: WebDriver) extends TestLogging with Matchers {
 
-  val jobsStub = "http://public-jobs-thegulocal-com.s3-website-eu-west-1.amazonaws.com"
+  val jobsStub = Config().getUserValue("jobsStubUrl")
 
   def goToJobsSite: JobsStubPage = {
     logger.step(s"I am on stub jobs page at url: $jobsStub")


### PR DESCRIPTION
Adds test for making sure we are showing terms and conditions for third party services on both sign in and registration, including the case where a user already has a Guardian account.

Social sign in buttons and terms and conditions are moved into traits, since those elements are shared between both `RegisterPage` and `SignInPage`.

To run, a new property needs to be added:

` "jobsStubUrl" : "http://public-jobs-thegulocal-com.s3-website-eu-west-1.amazonaws.com#thegulocal.com"`

where the last part should be `#thegulocal.com` or `#code.dev-theguardian.com` depending on the environment being tested.