### PR TITLE
Ensure user is added to group when reads T&Cs

### DIFF
--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/AgreePage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/AgreePage.scala
@@ -1,8 +1,16 @@
 package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.pages.common.ParentPage
-import org.openqa.selenium.WebDriver
+import com.gu.integration.test.util.ElementLoader._
+import org.openqa.selenium.support.ui.ExpectedConditions._
+import org.openqa.selenium.{WebElement, WebDriver}
 
 class AgreePage(implicit  driver: WebDriver) extends ParentPage with ThirdPartyConditions {
+  val continueLink: WebElement = findByDataLinkAttribute("Continue")
 
+  def clickContinue(): FrontPage  = {
+    waitUntil(visibilityOf(continueLink), 10)
+    continueLink.click()
+    new FrontPage()
+  }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/JobsStubPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/JobsStubPage.scala
@@ -28,5 +28,10 @@ class JobsStubPage(implicit  driver: WebDriver) extends ParentPage {
     new AgreePage
   }
 
+  def clickLoginAsApprovedUser(): FrontPage = {
+    waitUntil(visibilityOf(loginLink), 10)
+    loginLink.click()
+    new FrontPage
+  }
 
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsAndConditionsTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsAndConditionsTests.scala
@@ -1,5 +1,6 @@
 package com.gu.identity.integration.test.features
 
+import com.gu.automation.support.Config
 import com.gu.identity.integration.test.IdentitySeleniumTestSuite
 import com.gu.identity.integration.test.steps.{UserSteps, SignInSteps, TermsAndConditionsSteps}
 import com.gu.identity.integration.test.tags.CoreTest
@@ -45,6 +46,16 @@ class TermsAndConditionsTests extends IdentitySeleniumTestSuite {
       val user: User = UserSteps().createRandomBasicUser().right.get
       val agreePage = TermsAndConditionsSteps().goToJobsSite.clickLoginAsExistingUser()
       TermsAndConditionsSteps().checkJobsTermsVisible(agreePage)
+    }
+
+    scenarioWeb("should not see T&C's once user has accepted them", CoreTest) { implicit driver: WebDriver =>
+      UserSteps().createRandomBasicUser().right.get
+      val agreePage = TermsAndConditionsSteps().goToJobsSite.clickLoginAsExistingUser()
+      TermsAndConditionsSteps().checkJobsTermsVisible(agreePage)
+      agreePage.clickContinue()
+      BaseSteps().goToStartPage()
+      TermsAndConditionsSteps().goToJobsSite.clickLoginAsApprovedUser()
+      driver.getCurrentUrl should be(Config().getUserValue("jobsStubUrl"))
     }
   }
 


### PR DESCRIPTION
Make sure a user does not see the terms and conditions page twice when they have accepted them.