### PR TITLE
TOS test set to unstable

### DIFF
--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsOfServiceTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/TermsOfServiceTests.scala
@@ -1,14 +1,14 @@
 package com.gu.identity.integration.test.features
 
 import com.gu.identity.integration.test.IdentitySeleniumTestSuite
-import com.gu.identity.integration.test.tags.OptionalTest
+import com.gu.identity.integration.test.tags.{Unstable, OptionalTest}
 import com.gu.integration.test.steps.BaseSteps
 import org.openqa.selenium.WebDriver
 
 class TermsOfServiceTests extends IdentitySeleniumTestSuite {
 
   feature("Terms of Service feature") {
-    scenarioWeb("TOS1:  should not be empty or trivial", OptionalTest) { implicit driver: WebDriver =>
+    scenarioWeb("TOS1:  should not be empty or trivial", OptionalTest, Unstable) { implicit driver: WebDriver =>
       val tosPage = BaseSteps().goToTermsOfServicePage()
       val minimumTosContentSize = 100
       val tosContent: String = tosPage.getContent()


### PR DESCRIPTION
The test is too reliant on the front page being fully loaded and the ads not changing the layout in order to pass. 

Is it worthwhile keeping this test as it is not an important aspect of the site?