### PR TITLE
Reduce the amount of time taken to generate a random user

### DIFF
--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
@@ -19,6 +19,8 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage with ThirdPa
 
   private def registerWithFacebookButton: WebElement = findByTestAttribute("facebook-sign-in")
 
+  private def completeRegistrationButton: WebElement = findByDataLinkAttribute("Continue")
+
   def enterEmail(email: String) = {
     emailInputField.sendKeys(email)
     this
@@ -73,5 +75,9 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage with ThirdPa
     } catch {
       case _: org.openqa.selenium.NoSuchElementException => None
     }
+  }
+
+  def registrationComplete: Boolean = {
+    completeRegistrationButton.isDisplayed
   }
 }

--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/RegisterPage.scala
@@ -2,7 +2,7 @@ package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.util.ElementLoader._
 import com.gu.integration.test.util.WebElementEnhancer._
-import org.openqa.selenium.{StaleElementReferenceException, By, WebDriver, WebElement}
+import org.openqa.selenium.{By, StaleElementReferenceException, WebDriver, WebElement}
 
 class RegisterPage(implicit driver: WebDriver) extends UserFormPage with ThirdPartyConditions with SocialSignInButtons {
   private def emailInputField: WebElement = findByTestAttribute("reg-email")
@@ -19,7 +19,7 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage with ThirdPa
 
   private def registerWithFacebookButton: WebElement = findByTestAttribute("facebook-sign-in")
 
-  private def completeRegistrationButton: WebElement = findByDataLinkAttribute("Continue")
+  private def registerCompleteText: String = "Continue"
 
   def enterEmail(email: String) = {
     emailInputField.sendKeys(email)
@@ -78,6 +78,6 @@ class RegisterPage(implicit driver: WebDriver) extends UserFormPage with ThirdPa
   }
 
   def registrationComplete: Boolean = {
-    completeRegistrationButton.isDisplayed
+    dataLinkElementExists(registerCompleteText)
   }
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/UserTests.scala
@@ -18,8 +18,8 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
   feature("Create and changing a User") {
 
     scenarioWeb("U1: should not be able to create user with existing user name", CoreTest) { implicit driver: WebDriver =>
-      val validationErrors : List[FormError] = UserSteps().createUserWithUserName(get("loginName")).left.value
-      validationErrors should contain (FormError("This username has already been taken"))
+      val validationErrors: List[FormError] = UserSteps().createUserWithUserName(get("loginName")).left.value
+      validationErrors should contain(FormError("This username has already been taken"))
     }
 
     scenarioWeb("U2: should be able to change email address", CoreTest) { implicit driver: WebDriver =>
@@ -84,8 +84,8 @@ class UserTests extends IdentitySeleniumTestSuite with EitherValues {
       val passwordResetSentPage = UserSteps().requestToResetPassword(new ContainerWithSigninModulePage())
       UserSteps().checkUserGotPasswordResetSentMessage(passwordResetSentPage)
     }
-    
-	scenarioWeb("U7: should be able to go back to return URL after registration") { implicit driver: WebDriver =>
+
+    scenarioWeb("U7: should be able to go back to return URL after registration") { implicit driver: WebDriver =>
       val subPath = "/sport"
       val expectedReturnUrl = PageLoader.turnOfPopups(PageLoader.frontsBaseUrl + subPath)
       UserSteps().createRandomBasicUser(Some(subPath)).right.value

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/RegisterSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/RegisterSteps.scala
@@ -33,8 +33,7 @@ case class RegisterSteps(implicit driver: WebDriver) extends TestLogging with Ma
     if (registerPage.registrationComplete) { //finding the errors takes time so only do so if the button is not visible
       Right(user)
     } else {
-      val userFormErrors = registerPage.getAllValidationFormErrors
-      Left(userFormErrors)
+      Left(registerPage.getAllValidationFormErrors)
     }
   }
 

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/RegisterSteps.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/steps/RegisterSteps.scala
@@ -3,7 +3,6 @@ package com.gu.identity.integration.test.steps
 import com.gu.automation.support.TestLogging
 import com.gu.identity.integration.test.pages.RegisterPage
 import com.gu.identity.integration.test.util.{FormError, User}
-import com.gu.integration.test.util.PageLoader._
 import org.openqa.selenium.WebDriver
 import org.scalatest.Matchers
 
@@ -31,14 +30,11 @@ case class RegisterSteps(implicit driver: WebDriver) extends TestLogging with Ma
 
     registerPage.clickCreateUser()
 
-    waitForPageToLoad
-
-    val userFormErrors = registerPage.getAllValidationFormErrors
-
-    if (userFormErrors.nonEmpty) {
-      Left(userFormErrors)
-    } else {
+    if (registerPage.registrationComplete) { //finding the errors takes time so only do so if the button is not visible
       Right(user)
+    } else {
+      val userFormErrors = registerPage.getAllValidationFormErrors
+      Left(userFormErrors)
     }
   }
 


### PR DESCRIPTION
I have added a check into the tests to first check the registration is successful before looking for errors.  The collection of errors code runs quite slowly - adds about 15s to each test that uses it. 

There is a side-effect that the tests that generate a random user and expect to see an error now take 15s longer to run.  However there is only 1 of those tests so overall the tests run about a minute faster.

I also tidied up some of the code in the element loader class and the whitespacing in the user tests class 