### PR TITLE
Fixing failing social sign in tests

### DIFF
--- a/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/GoogleSignInPage.scala
+++ b/identity-tests/src/main/scala/com/gu/identity/integration/test/pages/GoogleSignInPage.scala
@@ -1,7 +1,7 @@
 package com.gu.identity.integration.test.pages
 
 import com.gu.integration.test.pages.common.ParentPage
-import org.openqa.selenium.{By, WebDriver, WebElement}
+import org.openqa.selenium.{JavascriptExecutor, By, WebDriver, WebElement}
 
 class GoogleSignInPage(implicit driver: WebDriver) extends ParentPage {
   private def emailInputField: WebElement = driver.findElement(By.id("Email"))
@@ -22,5 +22,7 @@ class GoogleSignInPage(implicit driver: WebDriver) extends ParentPage {
   def clickLogInButton = {
     loginInButton.click()
     waitForPageToLoad // workaround to stabilise too rapid selenium actions
+    //chrome browser flicks user down to random place in content after signing in with Google+ so scroll back to top
+    driver.asInstanceOf[JavascriptExecutor].executeScript("scroll(0, -400)")
   }
 }

--- a/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
+++ b/identity-tests/src/test/scala/com/gu/identity/integration/test/features/SocialNetworkTests.scala
@@ -6,7 +6,7 @@ import com.gu.identity.integration.test.steps.{SignInSteps, SocialNetworkSteps, 
 import com.gu.identity.integration.test.tags.{CoreTest, OptionalTest, SocialTest}
 import com.gu.identity.integration.test.util.facebook.FacebookTestUser
 import com.gu.integration.test.steps.BaseSteps
-import org.openqa.selenium.{JavascriptExecutor, WebDriver}
+import org.openqa.selenium.WebDriver
 import org.scalatest.Tag
 
 
@@ -146,7 +146,6 @@ class SocialNetworkTests extends IdentitySeleniumTestSuite {
       implicit driver: WebDriver =>
         BaseSteps().goToStartPage()
         SignInSteps().signInUsingGoogle()
-        driver.asInstanceOf[JavascriptExecutor].executeScript("javascript:window.scrollTop") //chrome browser flicks user down to content after signing in with Google+ so scroll back to top
         val editAccountDetailsPage = UserSteps().goToEditProfilePage(new ContainerWithSigninModulePage())
         SocialNetworkSteps().checkUserGotReAuthenticationMessage(editAccountDetailsPage)
         val googleConfirmPasswordDialog = editAccountDetailsPage.clickConfirmWithGoogleButton


### PR DESCRIPTION
I have moved the google+ sign in work around (chrome scrolls down after user signs in with Google+) to the page level rather than on only 1 test.  

I also changed the scroll as the more correct option of 
`.executeScript("javascript:window.scrollTop")` was not actually scrolling to the top when dealing with certain ads.  This has been replaced with the more fragile option of `.executeScript("scroll(0, -400)")`

